### PR TITLE
Refactor DiscordBot to accept a token as an initialization variable

### DIFF
--- a/examples/run_discordbot.js
+++ b/examples/run_discordbot.js
@@ -2,6 +2,8 @@ const TodoPlugin = require('../src/plugins/todo.js');
 const WeatherPlugin = require('../src/plugins/weather.js');
 const DiscordBot = require('../src/discordbot.js');
 
+// TODO: Implement a host variable for todo plugin for local dynamodb. Also
+// add optional variables to access key and secret key
 let plugins = [
   new TodoPlugin({
     'aws_region': 'us-west-2'
@@ -9,5 +11,6 @@ let plugins = [
   new WeatherPlugin
 ];
 
-let bot = new DiscordBot(plugins);
+let token = process.env.DISCORD_TOKEN;
+let bot = new DiscordBot(token, plugins);
 bot.start();

--- a/src/discordbot.js
+++ b/src/discordbot.js
@@ -7,6 +7,7 @@ const Discord = require('discord.js');
 class DiscordBot {
   constructor(token, plugins) {
     this.client = new Discord.Client();
+    this.discord_token = token;
     this.plugins = plugins;
   }
 
@@ -17,7 +18,7 @@ class DiscordBot {
   }
 
   login() {
-    this.client.login(process.env.DISCORD_TOKEN);
+    this.client.login(this.discord_token);
   }
 
   ready() {


### PR DESCRIPTION
This will allow the user to determine how they will obtain the token for the bot. For example, a user may want to load a configuration file that contains the token.